### PR TITLE
Support validator keys replacement for testnets

### DIFF
--- a/cmd/sentinelhub/cmd/pubkey_replacement.go
+++ b/cmd/sentinelhub/cmd/pubkey_replacement.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/x/genutil/types"
+	slashing "github.com/cosmos/cosmos-sdk/x/slashing/types"
+	staking "github.com/cosmos/cosmos-sdk/x/staking/types"
+	"github.com/pkg/errors"
+	cryptocodec "github.com/tendermint/tendermint/crypto/encoding"
+	tmtypes "github.com/tendermint/tendermint/types"
+)
+
+type replacementConfigs []replacementConfig
+
+func (r *replacementConfigs) isReplacedValidator(validatorAddress string) (int, replacementConfig) {
+
+	for i, replacement := range *r {
+		if replacement.ValidatorAddress == validatorAddress {
+			return i, replacement
+		}
+	}
+
+	return -1, replacementConfig{}
+}
+
+type replacementConfig struct {
+	Name             string `json:"validator_name"`
+	ValidatorAddress string `json:"validator_address"`
+	ConsensusPubkey  string `json:"stargate_consensus_public_key"`
+}
+
+func loadKeydataFromFile(clientCtx client.Context, replacementrJSON string, genDoc *tmtypes.GenesisDoc) *tmtypes.GenesisDoc {
+	jsonReplacementBlob, err := ioutil.ReadFile(replacementrJSON)
+	if err != nil {
+		log.Fatal(errors.Wrapf(err, "failed to read replacement keys from file %s", replacementrJSON))
+	}
+
+	var replacementKeys replacementConfigs
+
+	err = json.Unmarshal(jsonReplacementBlob, &replacementKeys)
+
+	if err != nil {
+		log.Fatal("Could not unmarshal replacement keys ")
+	}
+
+	var state types.AppMap
+	if err := json.Unmarshal(genDoc.AppState, &state); err != nil {
+		log.Fatal(errors.Wrap(err, "failed to JSON unmarshal initial genesis state"))
+	}
+
+	var stakingGenesis staking.GenesisState
+	var slashingGenesis slashing.GenesisState
+
+	clientCtx.JSONMarshaler.MustUnmarshalJSON(state[staking.ModuleName], &stakingGenesis)
+	clientCtx.JSONMarshaler.MustUnmarshalJSON(state[slashing.ModuleName], &slashingGenesis)
+
+	for i, val := range stakingGenesis.Validators {
+		idx, replacement := replacementKeys.isReplacedValidator(val.OperatorAddress)
+
+		if idx != -1 {
+
+			toReplaceValConsAddress, _ := val.GetConsAddr()
+
+			consPubKey, err := sdk.GetPubKeyFromBech32(sdk.Bech32PubKeyTypeConsPub, replacement.ConsensusPubkey)
+
+			if err != nil {
+				log.Fatal(fmt.Errorf("failed to decode key:%s %w", consPubKey, err))
+			}
+
+			val.ConsensusPubkey, err = codectypes.NewAnyWithValue(consPubKey)
+			if err != nil {
+				log.Fatal(fmt.Errorf("failed to decode key:%s %w", consPubKey, err))
+			}
+
+			replaceValConsAddress, _ := val.GetConsAddr()
+			protoReplaceValConsPubKey, _ := val.TmConsPublicKey()
+			replaceValConsPubKey, _ := cryptocodec.PubKeyFromProto(protoReplaceValConsPubKey)
+
+			for i, signingInfo := range slashingGenesis.SigningInfos {
+				if signingInfo.Address == toReplaceValConsAddress.String() {
+					slashingGenesis.SigningInfos[i].Address = replaceValConsAddress.String()
+					slashingGenesis.SigningInfos[i].ValidatorSigningInfo.Address = replaceValConsAddress.String()
+				}
+			}
+
+			for i, missedInfo := range slashingGenesis.MissedBlocks {
+				if missedInfo.Address == toReplaceValConsAddress.String() {
+					slashingGenesis.MissedBlocks[i].Address = replaceValConsAddress.String()
+				}
+			}
+
+			for tmIdx, tmval := range genDoc.Validators {
+				if tmval.Address.String() == replaceValConsAddress.String() {
+					genDoc.Validators[tmIdx].Address = replaceValConsAddress.Bytes()
+					genDoc.Validators[tmIdx].PubKey = replaceValConsPubKey
+
+				}
+			}
+			stakingGenesis.Validators[i] = val
+
+		}
+
+	}
+	state[staking.ModuleName] = clientCtx.JSONMarshaler.MustMarshalJSON(&stakingGenesis)
+	state[slashing.ModuleName] = clientCtx.JSONMarshaler.MustMarshalJSON(&slashingGenesis)
+
+	genDoc.AppState, err = json.Marshal(state)
+
+	if err != nil {
+		log.Fatal("Could not marshal App State")
+	}
+	return genDoc
+
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
+	github.com/pkg/errors v0.9.1
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/cobra v1.1.3
 	github.com/tendermint/tendermint v0.34.9


### PR DESCRIPTION
- Add support validator keys replacement in migrate command
- Add support custom chain_id
- Add support for min gensis time
- Add support for initial height


JSON file for validator keys replacement looks like this

```json
[
   {
      "validator_name":"dimi",
      "validator_address":"sentvaloper1s33zct2zhhaf60x4a90cpe9yquw99jj0s4egd3",
      "stargate_consensus_public_key":"sentvalconspub1zcjduepqc2xgyjsmdd4my9sf4hy8jmscxkw7qvhu9uzrmcjcv7c2890du89qmfdvz2"
   },
   {
      "validator_name":"stake.fish",
      "validator_address":"sentvaloper14xtpvapsx2kek5yn45xx9ccmuuyvgj77cxt5k0",
      "stargate_consensus_public_key":"sentvalconspub1zcjduepqjnvvezgndgxd78tjzpj4vlp5nnd852y200snhrpswvn59cgzp0xq5qp64c"
   }
]
```

thanks https://github.com/jackzampolin & tendermint for the original code