### PR TITLE
Change index args[1] in txSubscribe()

### DIFF
--- a/x/node/client/cli/tx.go
+++ b/x/node/client/cli/tx.go
@@ -160,7 +160,7 @@ func txSubscribe() *cobra.Command {
 				addr,
 				gigabytes,
 				hours,
-				args[2],
+				args[1],
 			)
 			if err = msg.ValidateBasic(); err != nil {
 				return err


### PR DESCRIPTION
You had an index out of range when it was args[2] since there is only two arguments (args[0] - node-addr, args[1] - denom)